### PR TITLE
Make pieces selectable

### DIFF
--- a/app/assets/javascripts/pieces.coffee
+++ b/app/assets/javascripts/pieces.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -21,11 +21,19 @@
  }
  
  .black {
- 	background-color:  #809fff;
+ 	background-color:  gray;
  }
 
  .icon {
  	height: 45px;
  	width: 45px;
  	margin: 5px auto;
+ }
+
+ .selected {
+ 	zoom: 1.2;
+ 	padding: 3px;
+ 	border: 1px solid black;
+ 	margin: 1px auto;
+
  }

--- a/app/assets/stylesheets/pieces.scss
+++ b/app/assets/stylesheets/pieces.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Pieces controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -1,0 +1,20 @@
+class PiecesController < ApplicationController
+	def update
+		@current = Piece.find_by_id(params[:id])
+		@game = Game.find_by_id(@current.game_id)
+		@pieces = @game.pieces
+		
+		@pieces.each do |piece|
+			piece.update_attribute(:is_selected, false)
+		end
+		
+		@current.update_attribute(:is_selected, true)
+		redirect_to game_path(@game)
+
+	end
+
+	private
+	def pieces_params 
+		params.require(:piece).permit(:is_selected, :game_id, :piece_id)
+	end
+end

--- a/app/helpers/pieces_helper.rb
+++ b/app/helpers/pieces_helper.rb
@@ -1,0 +1,2 @@
+module PiecesHelper
+end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -7,8 +7,10 @@
 			<% tile_id = "#{row}-#{col}" %>
 			<div class = "tile <%=tile_color%>" id = "<%=tile_id%>" > 
 			<% @pieces.each do |piece| %>
-				<% if piece.tile_id == tile_id %>
-					<%= image_tag piece.image, class: "img-responsive icon" %> 
+				<% if piece.tile_id == tile_id && piece.is_selected %>
+					<%= image_tag piece.image, class: "img-responsive icon selected"  %> 
+				<% elsif piece.tile_id == tile_id %>
+					<%= link_to image_tag(piece.image, class: "img-responsive icon"), piece_path(piece), method: :patch  %> 
 					<% break %>
 				<% end %>
 			<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
    root 'games#index'
    resources :games, only: [:new, :create, :destroy, :show, :update]
+   resources :pieces, only: [:update]
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/spec/controllers/pieces_controller_spec.rb
+++ b/spec/controllers/pieces_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PiecesController, type: :controller do
+
+end

--- a/spec/helpers/pieces_helper_spec.rb
+++ b/spec/helpers/pieces_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PiecesHelper. For example:
+#
+# describe PiecesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PiecesHelper, type: :helper do
+ 
+end


### PR DESCRIPTION
So at this point, any piece is selectable, but later I think we'll need to limit it to white player or black player pieces, depending on whose turn it is. When a piece is clicked, it's selected and marked as such with a box around it. This action also deselects any other pieces, and once a piece is selected, it can't be clicked on again until it's deselected, if that makes sense. 

I think for the next step, clicking a square to move onto, we could only make a tile clickable if its empty or inhabited by an enemy piece. That would mean we wouldn't have to make sure the destination square isn't inhabited by a friendly piece, but it's just an idea. 
